### PR TITLE
Bugfix - app.c - input not immediately displayed

### DIFF
--- a/src/app/app.c
+++ b/src/app/app.c
@@ -78,4 +78,5 @@ static void dump_byte_as_hex(uint8_t byte)
         printf("\n");
         count = 0;
     }
+    fflush(stdout);
 }


### PR DESCRIPTION
# BUGFIX

## Description
Incoming serial data not immediately displayed. It's buffered and only displays after a period of time.

## Fix
Add `fflush(stdout` to the function that attempts to display the incoming data.

#### File: `app.c`
#### Function: `dump_byte_as_hex`

#### Old Code
```c
static void dump_byte_as_hex(uint8_t byte)
{
    static int count = 0;
    printf("%02X ", byte);
    count++;
    if (count == 16)
    {
        printf("\n");
        count = 0;
    }
}
```
#### New Code
```c
static void dump_byte_as_hex(uint8_t byte)
{
    static int count = 0;
    printf("%02X ", byte);
    count++;
    if (count == 16)
    {
        printf("\n");
        count = 0;
    }
    fflush(stdout); // <--- Added this line
}
```