### PR TITLE
update makefile.yml to only run analysis on pull requests

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -41,6 +41,7 @@ jobs:
       - run: ./scripts/process_results.sh
       - name: Analysis Comment
         uses: thollander/actions-comment-pull-request@v2
+        if: github.event_name == 'pull_request'
         with:
           filePath: ./build/test/process/results.md
           comment_tag: analysis


### PR DESCRIPTION
# Original Problem: 
The makefile.yml and scripts all work properly (they all pass) when the pull-request is created, but the following error is created when you rebase and merge the PR back to main:
```
Run thollander/actions-comment-pull-request@v2 with: filePath: ./build/test/process/results.md comment_tag: analysis GITHUB_TOKEN: *** mode: upsert create_if_not_exists: true Error: No issue/pull request in input neither in current context.
```

## Solution
The error message suggests that the GitHub action `thollander/actions-comment-pull-request@v2` is unable to find the pull request context when it's being run. This action is designed to comment on pull requests, and it needs the pull request context to do so.

When you rebase and merge the PR back to main, the pull request is already closed, and the context of the pull request is lost. Therefore, the action can't find the pull request to comment on.

One possible solution is to ensure that this action only runs on pull request events. You can do this by adding a conditional to the step that uses `thollander/actions-comment-pull-request@v2`, like so:

```yaml
- name: Analysis Comment
  uses: thollander/actions-comment-pull-request@v2
  if: github.event_name == 'pull_request'
  with:
    filePath: ./build/test/process/results.md
    comment_tag: analysis
```

This will ensure that the action only runs when the event that triggered the workflow run is a pull request.